### PR TITLE
feat: stream tool-input-delta chunks to the client

### DIFF
--- a/src/client/streamer.ts
+++ b/src/client/streamer.ts
@@ -182,7 +182,7 @@ export class Streamer {
 }
 
 export function compactQueue(queue: Array<UIMessageChunk>): Array<UIMessageChunk> {
-  return joinAdjacentDeltas(queue.filter((part) => !(part.type === "tool-input-delta")).map(dropUnnecessaryInfo));
+  return joinAdjacentDeltas(queue.map(dropUnnecessaryInfo));
 }
 
 export function dropUnnecessaryInfo(chunk: UIMessageChunk): UIMessageChunk {


### PR DESCRIPTION
## Summary

- Stop filtering out `tool-input-delta` UIMessageChunks in `compactQueue`
- This allows the AI SDK's `readUIMessageStream` on the frontend to incrementally parse tool call arguments via `parsePartialJson`
- Partial `input` becomes available during the `input-streaming` state

## Motivation

Currently `compactQueue` strips all `tool-input-delta` chunks before writing to the database. This means the frontend only sees the completed tool input (after `tool-input-end`), never the incremental state.

With this change, the AI SDK's partial JSON parser reconstructs `input` progressively as deltas arrive. This enables use cases like showing a real-time character count while a file-write tool generates content, rather than only displaying the count after the tool call completes.

## Change

One line — remove the `.filter((part) => !(part.type === "tool-input-delta"))` from `compactQueue`.

The `joinAdjacentDeltas` and `dropUnnecessaryInfo` transforms still apply to all chunks including tool-input-delta.

## Trade-off

More data written to the database during tool call generation (one row per delta batch vs. zero). This is bounded by the existing `throttleMs` flush interval on the Streamer.