### PR TITLE
feat: add transformUIMessageStream option to stream handler

### DIFF
--- a/src/client/handler.ts
+++ b/src/client/handler.ts
@@ -7,6 +7,7 @@ import {
   type Tool,
   tool,
   type UIMessage,
+  type UIMessageStreamPart,
 } from "ai";
 import { type FunctionReference, type GenericActionCtx, internalActionGeneric } from "convex/server";
 import { v } from "convex/values";
@@ -125,6 +126,8 @@ export type StreamHandlerArgs = Omit<Parameters<typeof streamText>[0], "tools" |
   workpoolEnqueueAction?: FunctionReference<"mutation", "internal">;
   /** Optional: Override workpool for tool execution only */
   toolExecutionWorkpoolEnqueueAction?: FunctionReference<"mutation", "internal">;
+  /** Optional: Transform the UI message stream before the streamer iterates over it */
+  transformUIMessageStream?: (stream: ReadableStream<UIMessageStreamPart>) => ReadableStream<UIMessageStreamPart>;
 };
 
 export type StreamHandlerArgsFactory = (
@@ -313,13 +316,16 @@ export function streamHandlerAction(
           let finishReason: string | undefined;
           let responseMessage: UIMessage | undefined;
 
-          const uiMessageStream = result.toUIMessageStream({
+          let uiMessageStream = result.toUIMessageStream({
             generateMessageId: generateId,
             originalMessages: uiMessages,
             onFinish: ({ responseMessage: finalResponseMessage }) => {
               responseMessage = finalResponseMessage;
             },
           });
+          if (resolvedArgs.transformUIMessageStream) {
+            uiMessageStream = resolvedArgs.transformUIMessageStream(uiMessageStream);
+          }
 
           let msgId: string | undefined;
           if (messages.length > 0) {


### PR DESCRIPTION
## Summary

- Add optional `transformUIMessageStream` callback to `StreamHandlerArgs`
- Wraps the `toUIMessageStream()` result before the streamer iterates over it

## Motivation

Consumers may need to intercept or transform the UI message stream before it's processed by the streamer — for example, to inject custom stream parts, modify tool-input handling, or add logging/metrics around specific chunk types.

Currently there's no hook between `result.toUIMessageStream()` and the `for await (const part of uiMessageStream)` loop. This makes it impossible to customize stream behavior without forking the handler.

## Change

```ts
// StreamHandlerArgs
transformUIMessageStream?: (stream: ReadableStream<UIMessageStreamPart>) => ReadableStream<UIMessageStreamPart>;
```

In the handler, after `toUIMessageStream()` and before iteration:

```ts
let uiMessageStream = result.toUIMessageStream({ ... });
if (resolvedArgs.transformUIMessageStream) {
  uiMessageStream = resolvedArgs.transformUIMessageStream(uiMessageStream);
}
```

## Usage

```ts
streamHandlerAction(component, {
  model: openai("gpt-4o"),
  tools: { ... },
  transformUIMessageStream: (stream) =>
    stream.pipeThrough(new TransformStream({
      transform(chunk, controller) {
        // custom logic per chunk
        controller.enqueue(chunk);
      },
    })),
});
```

Fully opt-in — no behavior change when the option is omitted.