### PR TITLE
feat: add includeToolInputDeltas streaming option

### DIFF
--- a/src/client/handler.ts
+++ b/src/client/handler.ts
@@ -39,6 +39,8 @@ import { getStreamTextProviderMetadata, getStreamTextUsage, type UsageInfo } fro
 export type StreamingOptions = {
   throttleMs?: number;
   returnImmediately?: boolean;
+  /** Include tool-input-delta chunks in the stream, enabling incremental tool call input on the client. Default: false */
+  includeToolInputDeltas?: boolean;
 };
 
 const DEFAULT_STREAMING_OPTIONS: StreamingOptions = {
@@ -218,6 +220,7 @@ export function streamHandlerAction(
         threadId: args.threadId as Id<"threads">,
         streamId: args.streamId as Id<"streams">,
         lockId,
+        includeToolInputDeltas: streamingOptions.includeToolInputDeltas ?? false,
       });
       logger.debug("Acquiring stream lock...");
       const stream = await streamer.acquireLock().catch((e) => {

--- a/src/client/streamer.ts
+++ b/src/client/streamer.ts
@@ -24,6 +24,7 @@ export class Streamer {
       lockId: string;
       threadId: Id<"threads">;
       streamId: Id<"streams">;
+      includeToolInputDeltas: boolean;
     },
   ) {
     this.#logger = new Logger(`streamer:${config.streamId}`);
@@ -129,7 +130,7 @@ export class Streamer {
     try {
       const queue = this.#queue;
       this.#queue = [];
-      const compacted = compactQueue(queue);
+      const compacted = compactQueue(queue, this.config.includeToolInputDeltas);
       if (compacted.length === 0) {
         this.#logger.debug(`Skipping delta write: seq=${this.#seq}, rawParts=${queue.length}, compactedParts=0`);
         return;
@@ -181,8 +182,9 @@ export class Streamer {
   }
 }
 
-export function compactQueue(queue: Array<UIMessageChunk>): Array<UIMessageChunk> {
-  return joinAdjacentDeltas(queue.filter((part) => !(part.type === "tool-input-delta")).map(dropUnnecessaryInfo));
+export function compactQueue(queue: Array<UIMessageChunk>, includeToolInputDeltas = false): Array<UIMessageChunk> {
+  const filtered = includeToolInputDeltas ? queue : queue.filter((part) => part.type !== "tool-input-delta");
+  return joinAdjacentDeltas(filtered.map(dropUnnecessaryInfo));
 }
 
 export function dropUnnecessaryInfo(chunk: UIMessageChunk): UIMessageChunk {


### PR DESCRIPTION
## Summary

Add opt-in `includeToolInputDeltas` flag to `StreamingOptions` that preserves `tool-input-delta` chunks through `compactQueue`, enabling incremental tool call input on the client.

## Change

- `StreamingOptions.includeToolInputDeltas?: boolean` (default `false`)
- Passed through to `Streamer` config → `compactQueue`
- When `false` (default): current behavior, deltas filtered out
- When `true`: deltas stored in DB, frontend receives them via `readUIMessageStream` which parses partial JSON incrementally

## Usage

```ts
streamHandlerAction(component, {
  model: anthropic("claude-sonnet-4-20250514"),
  tools: { ... },
  saveStreamDeltas: {
    includeToolInputDeltas: true,
  },
});
```

On the frontend, `input` on tool-call parts updates incrementally during `input-streaming` state as the AI SDK's `parsePartialJson` reconstructs the arguments from each delta.

## Trade-off

More DB writes per flush when enabled (tool-input-delta chunks included). Bounded by existing `throttleMs` batching.