### PR TITLE
fix: cancel pending flush timeout in Streamer.fail()

### DIFF
--- a/src/client/streamer.test.ts
+++ b/src/client/streamer.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { Streamer } from "./streamer.js";
+
+/**
+ * Minimal mocks for testing the Streamer in isolation.
+ * We only need the mutation calls the Streamer makes.
+ */
+function createMockCtx() {
+  return {
+    runQuery: vi.fn().mockResolvedValue(null),
+    runMutation: vi.fn().mockResolvedValue(null),
+    runAction: vi.fn().mockResolvedValue(null),
+    storage: {} as any,
+    auth: {} as any,
+    scheduler: { runAfter: vi.fn() } as any,
+  };
+}
+
+function createMockComponent() {
+  return {
+    streams: {
+      take: "streams:take" as any,
+      addDelta: "streams:addDelta" as any,
+      finish: "streams:finish" as any,
+      abort: "streams:abort" as any,
+      heartbeat: "streams:heartbeat" as any,
+    },
+  } as any;
+}
+
+function createStreamer(ctx = createMockCtx(), component = createMockComponent()) {
+  const streamer = new Streamer(component, ctx, {
+    throttleMs: 50,
+    heartbeatMs: 60_000,
+    lockId: "test-lock",
+    threadId: "test-thread" as any,
+    streamId: "test-stream" as any,
+    includeToolInputDeltas: false,
+  });
+  return { streamer, ctx, component };
+}
+
+describe("Streamer", () => {
+  describe("fail() cancels pending flush timeout", () => {
+    it("should not write deltas after fail() is called", async () => {
+      const { streamer, ctx } = createStreamer();
+      streamer.enableDeltaStreaming();
+      await streamer.setMessageId("msg-1", false);
+
+      // Queue some parts via process() — this schedules a throttled flush
+      await streamer.process({ type: "text-delta" as any, id: "t1", delta: "hello " });
+      await streamer.process({ type: "text-delta" as any, id: "t1", delta: "world" });
+
+      // Now call fail() — this should cancel the pending flush
+      await streamer.fail("Provider connection lost");
+
+      // Verify abort was called
+      expect(ctx.runMutation).toHaveBeenCalledWith("streams:abort", {
+        streamId: "test-stream",
+        reason: "Provider connection lost",
+      });
+
+      // Wait longer than the throttle interval to give the (cancelled) timeout
+      // a chance to fire if it wasn't properly cancelled
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      // addDelta should NEVER have been called — the flush was cancelled
+      const addDeltaCalls = ctx.runMutation.mock.calls.filter(
+        (call) => call[0] === "streams:addDelta",
+      );
+      expect(addDeltaCalls).toHaveLength(0);
+    });
+
+    it("should still flush deltas on finish() (happy path)", async () => {
+      const { streamer, ctx } = createStreamer();
+      streamer.enableDeltaStreaming();
+      await streamer.setMessageId("msg-1", false);
+
+      await streamer.process({ type: "text-delta" as any, id: "t1", delta: "hello" });
+
+      await streamer.finish();
+
+      // finish() should flush remaining deltas then mark stream finished
+      const addDeltaCalls = ctx.runMutation.mock.calls.filter(
+        (call) => call[0] === "streams:addDelta",
+      );
+      expect(addDeltaCalls).toHaveLength(1);
+
+      expect(ctx.runMutation).toHaveBeenCalledWith("streams:finish", {
+        streamId: "test-stream",
+      });
+    });
+  });
+});

--- a/src/client/streamer.ts
+++ b/src/client/streamer.ts
@@ -170,6 +170,11 @@ export class Streamer {
 
   async fail(reason: string): Promise<void> {
     try {
+      if (this.#flushTimeout != null) {
+        clearTimeout(this.#flushTimeout);
+        this.#flushTimeout = undefined;
+      }
+      this.#queue = [];
       this.#logger.debug(`Aborting stream: ${reason}`);
       await this.ctx.runMutation(this.component.streams.abort, {
         streamId: this.config.streamId,


### PR DESCRIPTION
## Summary

- Cancel the pending throttled flush `setTimeout` and clear the queue in `Streamer.fail()` before aborting the stream
- Add unit tests for the Streamer verifying the fix (fails without, passes with)

Fixes #8

## Problem

When a provider connection drops mid-stream after tool call parts have been emitted, `Streamer.fail()` aborts the stream but does not cancel the pending flush scheduled by `process()`. The orphaned `setTimeout` fires after the stream is already aborted, writing a delta to an aborted stream. Since the flush is fire-and-forget (called from `setTimeout`, not awaited), the resulting error becomes an unhandled promise rejection that kills the Convex action before the handler's `finally` block runs — leaving the thread permanently stuck in `"streaming"` status.

## Fix

Three lines added to the top of `fail()`:
1. Clear the `#flushTimeout` if pending
2. Empty the `#queue` (deltas are irrelevant for a failing stream)

## Test plan

- [ ] `bun run test` — new unit test in `src/client/streamer.test.ts` verifies `fail()` cancels the flush (test fails without the fix, passes with it)
- [ ] Manual integration test with a mock model that drops connection after emitting tool call parts — thread should end in `"failed"` instead of being stuck in `"streaming"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)